### PR TITLE
Ack bidi flow

### DIFF
--- a/src/main/scala/com/github/dnvriend/stream/activemq/AckBidiFlow.scala
+++ b/src/main/scala/com/github/dnvriend/stream/activemq/AckBidiFlow.scala
@@ -1,0 +1,112 @@
+package com.github.dnvriend.stream.activemq
+
+import akka.actor.ActorSystem
+import akka.camel.CamelMessage
+import akka.stream._
+import akka.stream.scaladsl.{BidiFlow, Flow, GraphDSL, Keep}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.{Done, NotUsed}
+import com.github.dnvriend.stream.camel.{MessageBuilder, MessageExtractor}
+
+import scala.collection.immutable.Queue
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * This is a naive implementation of a bidirectional flow from/to ActiveMq; it assumes:
+  * - a 1 on 1 correspondence (bijection) between items sent from Out and received on In (see diagram)
+  * - that ordering is preserved between Out and In (see diagram); i.e. no mapAsyncUnordered, ideally no network-
+  * traversals; careful with dispatching to actors
+  * - that at-least-once-delivery is acceptable on ActiveMqSink
+  *
+  * This flow is practical for the typical use case of handling a request received from activemq, processing it with
+  * some bidi-flow, and dispatching a response to ActiveMq. The original requests gets acked once the response is sent.
+  *
+  * {{{
+  *                  +-------------+
+  * ActiveMqSource ~>|             |~> Out
+  *                  | AckBidiFlow |
+  * ActiveMqSink   <~|             |<~ In
+  *                  +-------------+
+  * }}}
+  */
+object AckBidiFlow {
+
+  def apply[S, T](consumerName: String,
+                  producerName: String,
+                  qos: Int = 8,
+                  queueSize: Int = 20)
+                 (implicit ec: ExecutionContext,
+                  system: ActorSystem,
+                  extractor: MessageExtractor[CamelMessage, S],
+                  builder: MessageBuilder[T, CamelMessage]): Flow[T, S, Future[Done]] = {
+
+    val amqSource = ActiveMqSource.apply(consumerName)
+    val amqSink = AckActiveMqSink.apply(producerName, qos)
+
+    Flow.fromGraph(GraphDSL.create(amqSource, amqSink)(Keep.right) { implicit b ⇒ (source, sink) ⇒
+      import GraphDSL.Implicits._
+
+      val bidi = b.add(AckBidiFlow[S, T](queueSize))
+
+      source ~> bidi.in1
+      bidi.out2 ~> sink
+
+      FlowShape(bidi.in2, bidi.out1)
+    })
+  }
+
+  def apply[S, T](queueSize: Int): BidiFlow[AckTup[S], S, T, AckTup[T], NotUsed] =
+    BidiFlow.fromGraph(new AckBidiFlow[S, T](queueSize))
+}
+
+class AckBidiFlow[S, T](queueSize: Int) extends GraphStage[BidiShape[AckTup[S], S, T, AckTup[T]]] {
+
+  var queue: Queue[AckTup[S]] = Queue.empty
+
+  val ackIn = Inlet[AckTup[S]]("AckBidiFlow.ackIn")
+  val downOut = Outlet[S]("AckBidiFlow.downOut")
+  val downIn = Inlet[T]("AckBidiFlow.downIn")
+  val ackOut = Outlet[AckTup[T]]("AckBidiFlow.ackOut")
+
+  override def shape: BidiShape[AckTup[S], S, T, AckTup[T]] = BidiShape.of(ackIn, downOut, downIn, ackOut)
+
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+    setHandler(ackIn, new InHandler {
+      @scala.throws[Exception](classOf[Exception])
+      override def onPush(): Unit = {
+        val request = grab(ackIn)
+        queue = queue.enqueue(request)
+        push(downOut, request._2)
+      }
+    })
+
+    setHandler(downOut, new OutHandler {
+      @scala.throws[Exception](classOf[Exception])
+      override def onPull(): Unit = {
+        tryPull(ackIn)
+      }
+    })
+
+    setHandler(downIn, new InHandler {
+      @scala.throws[Exception](classOf[Exception])
+      override def onPush(): Unit = {
+        val response = grab(downIn)
+        if (queue.isEmpty)
+          failStage(new RuntimeException(s"Received element $response, but requests queue is empty"))
+
+        val (ackRequest, newQueue) = queue.dequeue
+        queue = newQueue
+
+        val ackResponse = ackRequest.copy(_2 = response)
+        push(ackOut, ackResponse)
+      }
+    })
+
+    setHandler(ackOut, new OutHandler {
+      @scala.throws[Exception](classOf[Exception])
+      override def onPull(): Unit = tryPull(downIn)
+    })
+  }
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -73,6 +73,20 @@ PersonCopyProducer {
   topic = "PersonCopy"
 }
 
+AckBidiFlowTestInput {
+  conn = "amq"
+  topic = "AckBidiFlowOutput"
+  queue = "AckBidiFlowOutput"
+  concurrentConsumers = "1"
+}
+
+AckBidiFlowTestOutput {
+  conn = "amq"
+  topic = "AckBidiFlowOutput"
+  queue = "AckBidiFlowOutput"
+  concurrentConsumers = "1"
+}
+
 slick {
   driver = "slick.driver.PostgresDriver$"
   db {

--- a/src/test/scala/com/github/dnvriend/stream/activemq/AckBidiFlowTest.scala
+++ b/src/test/scala/com/github/dnvriend/stream/activemq/AckBidiFlowTest.scala
@@ -1,0 +1,125 @@
+package com.github.dnvriend.stream.activemq
+
+import akka.Done
+import akka.stream.FlowShape
+import akka.stream.scaladsl.{Flow, GraphDSL}
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.stream.testkit.{TestPublisher, TestSubscriber}
+import akka.testkit.TestProbe
+import com.github.dnvriend.stream.PersonDomain.Person
+import com.github.dnvriend.stream.TestSpec
+import com.github.dnvriend.stream.camel.JsonMessageBuilder._
+import com.github.dnvriend.stream.camel.JsonMessageExtractor._
+
+import scala.concurrent.{Future, Promise}
+
+
+class AckBidiFlowTest extends TestSpec {
+
+  behavior of "AckBidiFlow"
+
+  it should "propagate an element downstream, and propagate returned elements upstream, wrapped with the initial promise" in {
+    withAckBidiFlow { inputProbe ⇒ flowProbe ⇒ outputProbe ⇒
+
+      val inputPromise = Promise[Unit]()
+
+      inputProbe.sendNext((inputPromise, testPerson1))
+
+      flowProbe.expectNoMsg()
+
+      outputProbe.request(1)
+
+      flowProbe.expectMsg(testPerson1)
+
+      outputProbe.expectNoMsg()
+
+      flowProbe.reply(testPerson2)
+
+      val outputPromise = outputProbe.expectNextPF { case (p: Promise[Unit], `testPerson2`) ⇒ p }
+
+      inputPromise should equal(outputPromise)
+    }
+  }
+
+  it should "respect buffer size" in {
+    withAckBidiFlow { inputProbe ⇒ flowProbe ⇒ outputProbe ⇒
+
+      val inputPromise1 = Promise[Unit]()
+      val inputPromise2 = Promise[Unit]()
+      inputProbe.sendNext((inputPromise1, testPerson1))
+      inputProbe.sendNext((inputPromise2, testPerson2))
+
+      outputProbe.request(2)
+
+      flowProbe.expectMsg(testPerson1)
+
+      // assert that buffer-size of 1 is respected
+      flowProbe.expectNoMsg()
+    }
+  }
+
+  it should "propagate messages from input to output unmodified, if mediated by the identity flow" in {
+    withTestTopicPublisher("AckBidiFlowTestInput") { pub ⇒
+      withTestTopicSubscriber("AckBidiFlowTestOutput") { sub ⇒
+        withActiveMqBidiFlow("AckBidiFlowTestInput", "AckBidiFlowTestOutput") { flow ⇒
+
+          val identityFlow = Flow[Person].map(identity)
+          val program: Future[Done] = flow.join(identityFlow).run()
+
+          pub.sendNext(testPerson1)
+
+          sub.request(2)
+          sub.expectNextPF {
+            case (p: Promise[Unit], `testPerson1`) ⇒ p.success(())
+          }
+
+          pub.sendNext(testPerson2)
+          pub.sendComplete()
+
+          sub.expectNextPF {
+            case (p: Promise[Unit], `testPerson2`) ⇒ p.success(())
+          }
+          sub.cancel()
+        }
+      }
+    }
+  }
+
+
+  /**
+    * Creates an acknowledging bidirectional flow whose input, back-end and output can be manipulated using probes
+    */
+  def withAckBidiFlow(test: TestPublisher.Probe[AckTup[Person]] ⇒ TestProbe ⇒ TestSubscriber.Probe[AckTup[Person]] ⇒ Any): Unit = {
+    import akka.pattern.ask
+    val flowProbe = TestProbe()
+
+    val inputSource = TestSource.probe[AckTup[Person]]
+    val outputSink = TestSink.probe[AckTup[Person]]
+    val backendFlow = Flow[Person].mapAsync(1)(p ⇒ (flowProbe.ref ? p).mapTo[Person])
+
+    val partialTestFlow = Flow.fromGraph(GraphDSL.create(inputSource, outputSink)((_, _)) { implicit b ⇒ (source, sink) ⇒
+      import GraphDSL.Implicits._
+
+      val bidi = b.add(AckBidiFlow[Person, Person](1))
+
+      source ~> bidi.in1
+      bidi.out2 ~> sink
+
+      FlowShape(bidi.in2, bidi.out1)
+    })
+
+    val (inputProbe, outputProbe) = partialTestFlow.join(backendFlow).run()
+
+    test(inputProbe)(flowProbe)(outputProbe)
+  }
+
+
+  /**
+    * Creates an acknowledging bidirectional flow, connected with an ActiveMqSource and ActiveMqSink
+    *
+    * NOTE: Test using this fixture assume correct implementation of ActiveMqSource and ActiveMqSink!
+    */
+  def withActiveMqBidiFlow[S, T](sourceEndpoint: String, sinkEndpoint: String)
+                                (test: Flow[Person, Person, Future[Done]] ⇒ Any): Unit =
+    test(AckBidiFlow[Person, Person](sourceEndpoint, sinkEndpoint))
+}

--- a/src/test/scala/com/github/dnvriend/stream/activemq/ActiveMqSourceTest.scala
+++ b/src/test/scala/com/github/dnvriend/stream/activemq/ActiveMqSourceTest.scala
@@ -24,12 +24,12 @@ class ActiveMqSourceTest extends TestSpec {
   it should "consume messages from the queue" in {
     withTestTopicSubscriber() { sub ⇒
       withTestTopicPublisher() { pub ⇒
-        pub.sendNext(testPerson)
+        pub.sendNext(testPerson1)
         pub.sendComplete()
 
         sub.request(1)
         sub.expectNextPF {
-          case (p: Promise[Unit], `testPerson`) ⇒ p.success(())
+          case (p: Promise[Unit], `testPerson1`) ⇒ p.success(())
         }
         sub.cancel()
       }


### PR DESCRIPTION
Is this something you'd be interested in including? If so, any idea why the last test displays inconsistent success? :)

Perhaps some background for this PR; Most of my flows are fairly linear processes of the kind: 
1. receive request from AMQ
2. process request
3. respond to request on AMQ
4. acknowledge handling of request to consume the initial message.

This bidi-flow allows you to join with your application flow to do exactly that (reusing your ActiveMqSource and ActiveMqSink). It is quite primitive, but it does cover practical use cases.
