### PR TITLE
Extracted configuration from ActiveMqExtension. 

### DIFF
--- a/src/main/scala/akka/stream/integration/activemq/extension/config/ActiveMqConfig.scala
+++ b/src/main/scala/akka/stream/integration/activemq/extension/config/ActiveMqConfig.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.stream.integration.activemq.extension.config
+
+import com.typesafe.config.Config
+
+import scalaz.syntax.std.boolean._
+
+object ActiveMqConfig {
+  def apply(config: Config): ActiveMqConfig = ActiveMqConfig(
+    config.getString("host"),
+    config.getString("port"),
+    config.getString("user"),
+    config.getString("pass"),
+    config.hasPath("transport").option(config.getString("transport")).getOrElse("nio")
+  )
+}
+
+case class ActiveMqConfig(host: String, port: String, user: String, pass: String, transport: String)

--- a/src/main/scala/akka/stream/integration/activemq/extension/config/ConsumerConfig.scala
+++ b/src/main/scala/akka/stream/integration/activemq/extension/config/ConsumerConfig.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.stream.integration.activemq.extension.config
+
+import com.typesafe.config.Config
+
+object ConsumerConfig {
+  def apply(config: Config, name: Option[String] = None): ConsumerConfig = ConsumerConfig(
+    name.getOrElse(config.getString("name")),
+    config.getString("conn"),
+    config.getString("queue"),
+    config.getString("concurrentConsumers")
+  )
+}
+
+case class ConsumerConfig(name: String, conn: String, queue: String, concurrentConsumers: String) extends EndpointDefinition {
+  override lazy val endpoint: String = s"$conn:queue:Consumer.$name.VirtualTopic.$queue?concurrentConsumers=$concurrentConsumers"
+}

--- a/src/main/scala/akka/stream/integration/activemq/extension/config/EndpointDefinition.scala
+++ b/src/main/scala/akka/stream/integration/activemq/extension/config/EndpointDefinition.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.stream.integration.activemq.extension.config
+
+/**
+ *
+ */
+trait EndpointDefinition {
+  def endpoint: String
+}

--- a/src/main/scala/akka/stream/integration/activemq/extension/config/ProducerConfig.scala
+++ b/src/main/scala/akka/stream/integration/activemq/extension/config/ProducerConfig.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.stream.integration.activemq.extension.config
+
+import com.typesafe.config.Config
+
+import scalaz.syntax.std.boolean._
+
+object ProducerConfig {
+  def apply(config: Config): ProducerConfig = ProducerConfig(
+    config.getString("conn"),
+    config.getString("topic"),
+    config.hasPath("reply-to").option(config.getString("reply-to"))
+  )
+}
+
+case class ProducerConfig(conn: String, topic: String, replyTo: Option[String]) extends EndpointDefinition {
+  override lazy val endpoint: String = {
+    val maybeReplyTo = replyTo.map(dest ⇒ s"?replyTo=$dest&preserveMessageQos=true").getOrElse("")
+    s"$conn:topic:VirtualTopic.$topic$maybeReplyTo"
+  }
+}


### PR DESCRIPTION
Provides somewhat better separation of concerns, but more importantly, provides more freedom with respect to organising your configuration file. I.e. I can create flows without having source/sink definition in the root of my config file.
