### PR TITLE
Parallellism

### DIFF
--- a/src/main/scala/akka/stream/integration/activemq/ActiveMqConsumer.scala
+++ b/src/main/scala/akka/stream/integration/activemq/ActiveMqConsumer.scala
@@ -17,10 +17,11 @@
 package akka.stream.integration
 package activemq
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.NotUsed
+import akka.actor.{ActorRef, ActorSystem}
 import akka.stream.integration.activemq.extension.ActiveMqExtension
 import akka.stream.integration.camel.CamelActorPublisher
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Merge, Source}
 
 import scala.concurrent.ExecutionContext
 
@@ -30,30 +31,61 @@ object ActiveMqConsumer {
    * The consumed messages must be consumed by an [[akka.stream.integration.activemq.AckSink]]
    * for before the source will emit the next element.
    */
-  def apply[A: CamelMessageExtractor](consumerName: String)(implicit ec: ExecutionContext, system: ActorSystem): Source[AckUTup[A], ActorRef] =
-    source(consumerName)
+  def apply[A: CamelMessageExtractor](consumerName: String, poolSize: Int = 1)(implicit ec: ExecutionContext, system: ActorSystem): Source[AckUTup[A], NotUsed] =
+    source(consumerName, poolSize)
 
   /**
    * Creates a consumer that consumes messages from a configured ActiveMq consumer and produces responses to the
    * supplied response destination until upstream terminates. A consumed messages must be acknowledged by an
    * [[akka.stream.integration.activemq.AckSink]] completion Sink before the source will emit the next element.
    */
-  def apply[A: CamelMessageBuilder, B: CamelMessageExtractor](consumerName: String)(implicit ec: ExecutionContext, system: ActorSystem): Source[AckTup[A, B], ActorRef] =
-    requestResponseSource(consumerName)
+  def apply[A: CamelMessageBuilder, B: CamelMessageExtractor](consumerName: String, poolSize: Int)(implicit ec: ExecutionContext, system: ActorSystem): Source[AckTup[A, B], NotUsed] =
+    requestResponseSource(consumerName, poolSize)
 
   /**
    * Creates a consumer that consumes messages from a configured ActiveMq consumer until upstream terminates.
    * The consumed messages must be consumed by an [[akka.stream.integration.activemq.AckSink]]
    * for before the source will emit the next element.
    */
-  def source[A: CamelMessageExtractor](consumerName: String)(implicit ec: ExecutionContext, system: ActorSystem): Source[AckUTup[A], ActorRef] =
-    CamelActorPublisher.fromEndpointUriWithExtractor[A](ActiveMqExtension(system).consumerEndpointUri(consumerName)).via(new AckedFlow)
+  def source[A: CamelMessageExtractor](consumerName: String, poolSize: Int = 1)
+                                      (implicit ec: ExecutionContext, system: ActorSystem): Source[AckUTup[A], NotUsed] =
+    createActorPublishers(consumerName, system, poolSize).via(new AckedFlow)
+
 
   /**
    * Creates a consumer that consumes messages from a configured ActiveMq consumer and produces responses to the
    * supplied response destination until upstream terminates. A consumed messages must be acknowledged by an
    * [[akka.stream.integration.activemq.AckSink]] completion Sink before the source will emit the next element.
    */
-  def requestResponseSource[A: CamelMessageBuilder, B: CamelMessageExtractor](consumerName: String)(implicit ec: ExecutionContext, system: ActorSystem): Source[AckTup[A, B], ActorRef] =
-    CamelActorPublisher.fromEndpointUriWithExtractor[B](ActiveMqExtension(system).consumerEndpointUri(consumerName)).via(new AckedResponseFlow)
+  def requestResponseSource[A: CamelMessageBuilder, B: CamelMessageExtractor](consumerName: String, poolSize: Int = 1)
+                                                                             (implicit ec: ExecutionContext, system: ActorSystem): Source[AckTup[A, B], NotUsed] =
+  createActorPublishers(consumerName, system, poolSize).via(new AckedResponseFlow)
+
+
+  /**
+    * Instantiates a single camel-actor-publisher for the given configuration
+    */
+  protected def createActorPublisher[A: CamelMessageExtractor](consumerName: String, system: ActorSystem): Source[(ActorRef, A), ActorRef] =
+    CamelActorPublisher.fromEndpointUriWithExtractor[A](ActiveMqExtension(system).consumerEndpointUri(consumerName))
+
+
+  /**
+    * Creates a pool of camel-actor-publishers of size at least one. This defines the number of requests that can
+    * be in-transit in parallel.
+    */
+  protected def createActorPublishers[A: CamelMessageExtractor](consumerName: String, system: ActorSystem, poolSize: Int = 1): Source[(ActorRef, A), NotUsed] = {
+    poolSize match {
+      case 1 ⇒
+        createActorPublisher(consumerName, system).mapMaterializedValue(_ ⇒ NotUsed)
+
+      case n if n > 1 ⇒
+        val consumer1 = createActorPublisher(consumerName, system)
+        val consumer2 = createActorPublisher(consumerName, system)
+        val rest = (1 to n - 2).map(_ ⇒ createActorPublisher(consumerName, system))
+        Source.combine(consumer1, consumer2, rest: _*)(Merge(_))
+
+      case n ⇒
+        throw new java.lang.AssertionError(s"Expected positive value for poolSize, but got: $n")
+    }
+  }
 }

--- a/src/main/scala/akka/stream/integration/activemq/ActiveMqConsumer.scala
+++ b/src/main/scala/akka/stream/integration/activemq/ActiveMqConsumer.scala
@@ -75,16 +75,16 @@ object ActiveMqConsumer {
     */
   protected def createActorPublishers[A: CamelMessageExtractor](consumerName: String, system: ActorSystem, poolSize: Int = 1): Source[(ActorRef, A), NotUsed] = {
     poolSize match {
-      case 1 ⇒
-        createActorPublisher(consumerName, system).mapMaterializedValue(_ ⇒ NotUsed)
+      case 1 =>
+        createActorPublisher(consumerName, system).mapMaterializedValue(_ => NotUsed)
 
-      case n if n > 1 ⇒
+      case n if n > 1 =>
         val consumer1 = createActorPublisher(consumerName, system)
         val consumer2 = createActorPublisher(consumerName, system)
-        val rest = (1 to n - 2).map(_ ⇒ createActorPublisher(consumerName, system))
+        val rest = (1 to n - 2).map(_ => createActorPublisher(consumerName, system))
         Source.combine(consumer1, consumer2, rest: _*)(Merge(_))
 
-      case n ⇒
+      case n =>
         throw new java.lang.AssertionError(s"Expected positive value for poolSize, but got: $n")
     }
   }

--- a/src/main/scala/akka/stream/integration/activemq/ActiveMqFlow.scala
+++ b/src/main/scala/akka/stream/integration/activemq/ActiveMqFlow.scala
@@ -19,22 +19,19 @@ package activemq
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.camel.CamelMessage
 import akka.stream.FlowShape
-import akka.stream.scaladsl.{ Flow, GraphDSL, Keep, Sink, Source }
+import akka.stream.integration.activemq.RecorrelatorBidiFlow.Correlator
+import akka.stream.scaladsl.{Flow, GraphDSL, Keep, Sink, Source}
 
-import scala.concurrent.{ ExecutionContext, Promise }
+import scala.concurrent.{ExecutionContext, Promise}
 
 /**
- * This is a naive implementation of a bidirectional flow from/to ActiveMq; it assumes:
- * - that a 1 on 1 correspondence (bijection) exists between elements sent to - and received from the BACK-END
- * - that ordering is preserved between Out and In (see diagram); i.e. no mapAsyncUnordered, no foreachParallel,
- * ideally no network-traversals; careful with dispatching to actors, etc. If this property cannot be upheld due to
- * some stream-element's processing failing in an unexpected way, one will have to fail the graph
- * - that at-least-once-delivery is acceptable on ActiveMqSink
+ * This is an implementation of a bi-directional flow, with the use case of bridging between the (FRONT-END)
+ * interfacing stages and the (BACK-END) application flow. The front-end has a technical way of linking metadata to
+ * each request, such that the sink can acknowledge it. This bi-directional flow introduces some separation of concerns
+ * in that it hides that internal mechanism such that your application interface does not need to account for it.
  *
- * This flow is practical for the typical use case of handling a request received from activemq, processing it with
- * some bidi-flow, and dispatching a response to ActiveMq. The original requests gets acked once the response is sent.
+ * Of course, this introduces alternative constraints. Look at the particular constructor implementation for details.
  *
  * {{{
  *
@@ -51,10 +48,15 @@ import scala.concurrent.{ ExecutionContext, Promise }
 object ActiveMqFlow {
 
   /**
-   * Create an acknowledging bi-directional flow, with its FRONT-END-in hooked up to `source` and its FRONT-END-out
-   * hooked up to `sink`. This constructor is intended for cases where responses are sent to a fixed ActiveMq
-   * destination (i.e. the Sink)
-   */
+    * Create an acknowledging bi-directional flow, with its FRONT-END-in hooked up to `source` and its FRONT-END-out
+    * hooked up to `sink`. This constructor is intended for cases where the application behaves 'function-like'. This
+    * can be summarized as the following two properties:
+    * - ONE-ON-ONE: Each request needs exactly one response. This constraint exists with or without the addition of the
+    * bidirectional flow, but is enforced with the introduction of this bidi-flow. Not respecting the rule gives a
+    * guaranteed inconsistency w.r.t. the responses sent
+    * - ORDER-PRESERVING: For each two elements x,y dispatched to the BACK-END, if x happened-before y, the
+    * applications' response x' on x and y' on y should have x' ordered before y'
+    */
   def apply[S, T, M1, M2](source: Source[AckUTup[S], M1], sink: Sink[AckUTup[T], M2])(implicit ec: ExecutionContext, system: ActorSystem): Flow[T, S, NotUsed] = {
     applyMat(source, sink)(Keep.none)
   }
@@ -72,6 +74,36 @@ object ActiveMqFlow {
       FlowShape(bidi.in2, bidi.out1)
     })
   }
+
+  /**
+    * Create an acknowledging bi-directional flow, with its FRONT-END-in hooked up to `source` and its FRONT-END-out
+    * hooked up to `sink`. This constructor is intended for use cases where ordering of the BACK-END is not guaranteed.
+    * This bidi-flow does not restore the ordering, but its consistency is not threatened by it either.
+    *
+    * To do its work, it requires a correlator that extracts a correlation-identifier from the request and response.
+    * An internal buffer allows for the reconstruction of the original metadata with the response such that the FRONT-
+    * END knows how to acknowledge. No two messages in-transit may define the same correlation-identifier, as this will
+    * obviously threaten consistency. It is good practice to take something that is close to guaranteed to be unique,
+    * but once a request is handled, the correlation-id is effectively free for reuse.
+    */
+  def apply[C, S, T, M1, M2](source: Source[AckUTup[S], M1], sink: Sink[AckUTup[T], M2], correlator: Correlator[C, S, T])(implicit ec: ExecutionContext, system: ActorSystem): Flow[T, S, NotUsed] = {
+    applyMat(source, sink, correlator)(Keep.none)
+  }
+
+  def applyMat[C, S, T, M1, M2, Mat](source: Source[AckUTup[S], M1], sink: Sink[AckUTup[T], M2], correlator: Correlator[C, S, T])(combineMat: (M1, M2) => Mat)(implicit ec: ExecutionContext, system: ActorSystem): Flow[T, S, Mat] = {
+
+    Flow.fromGraph(GraphDSL.create(source, sink)(combineMat) { implicit b => (src, snk) =>
+      import GraphDSL.Implicits._
+
+      val bidi = b.add(RecorrelatorBidiFlow[Promise[Unit], C, S, T](correlator))
+
+      src ~> bidi.in1
+      bidi.out2 ~> snk
+
+      FlowShape(bidi.in2, bidi.out1)
+    })
+  }
+
 
   /**
    * Create a bidi-flow that is linked up to an ActiveMqSource and ActiveMqSink by their configuration name

--- a/src/main/scala/akka/stream/integration/activemq/ActiveMqReqRespFlow.scala
+++ b/src/main/scala/akka/stream/integration/activemq/ActiveMqReqRespFlow.scala
@@ -77,6 +77,6 @@ object ActiveMqReqRespFlow {
   /**
    * Create a bidi-flow that is linked up to an ActiveMqSource that is expected to execute a request-response pattern
    */
-  def apply[S: CamelMessageExtractor, T: CamelMessageBuilder](consumerName: String)(implicit ec: ExecutionContext, system: ActorSystem): Flow[T, S, NotUsed] =
-    apply(ActiveMqConsumer[T, S](consumerName), AckSink.complete[T])
+  def apply[S: CamelMessageExtractor, T: CamelMessageBuilder](consumerName: String, poolSize: Int = 1)(implicit ec: ExecutionContext, system: ActorSystem): Flow[T, S, NotUsed] =
+    apply(ActiveMqConsumer[T, S](consumerName, poolSize), AckSink.complete[T])
 }

--- a/src/main/scala/akka/stream/integration/activemq/RecorrelatorBidiFlow.scala
+++ b/src/main/scala/akka/stream/integration/activemq/RecorrelatorBidiFlow.scala
@@ -1,0 +1,117 @@
+package akka.stream.integration.activemq
+
+import akka.stream.integration.activemq.RecorrelatorBidiFlow.Correlator
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, BidiShape, Inlet, Outlet}
+
+/**
+  *
+  */
+object RecorrelatorBidiFlow {
+
+  trait Correlator[C, I, O] {
+
+    /**
+      * Use this to extract an identifier from the request that can be used to correlate its response
+      */
+    def extractRequestCorrelation: I ⇒ C
+
+    /**
+      * Use this to extract from a response that can be used to correlate it to the original request
+      */
+    def correlateResponse: O ⇒ C
+  }
+
+  def apply[CIn, CMem, Req, Resp](correlator: Correlator[CMem, Req, Resp]): RecorrelatorBidiFlow[CIn, CMem, Req, Resp] = {
+    new RecorrelatorBidiFlow[CIn, CMem, Req, Resp](correlator)
+  }
+}
+
+/**
+  *
+  * This Recorrelator bidirectional flow allows one to link two flows with separate correlation-mechanisms. In the
+  * intended use case, the back-end has a more business-oriented mechanism (some business-process-identifier with each
+  * message), and the front-end a more technical one (the acknowledgment flow using actor-refs or promises to
+  * acknowledge a request to ActiveMq).
+  *
+  * The Recorrelator flow expects a Correlator instance, which extracts a correlation identifier from the request (the
+  * message that passes from front-end to back-end) and the response (the message passing from back-end to front-end).
+  * This flow preserves both identifiers s.t. the front-end correlator can be provided to the front-end, along with
+  * the response from the back-end.
+  *
+  * Important constraints:
+  * - The back-end flow is expected to be ONE-ON-ONE: For each request, it will eventually provide a response. If no
+  * response can be created, the back-end flow should terminate with error, or suffer that the internal buffer of the
+  * Recorrelator will grow unbounded.
+  *
+  * @param correlator
+  * @tparam CIn The correlation 'identifier' used on the front-end route
+  * @tparam CMem The correlation identifier persisted
+  * @tparam Req The request message type propagated from front-end to back-end
+  * @tparam Resp The response message type propagated from back-end to front-end
+  *
+  * TODO:
+  * - Set a(n optional) buffer limit
+  * - Add TTL to messages in-transit
+  * - Add a strategy for how to deal with TTLs: (crash-if-TTL-exceeded, crash-on-late-response, dispatch-empty-response vs. drop-request? request-without-response?)
+  */
+class RecorrelatorBidiFlow[CIn, CMem, Req, Resp](correlator: Correlator[CMem, Req, Resp]) extends GraphStage[BidiShape[(CIn, Req), Req, Resp, (CIn, Resp)]] {
+
+  val in1: Inlet[(CIn, Req)] = Inlet[(CIn, Req)]("in1")
+  val out1: Outlet[Req] = Outlet[Req]("out1")
+  val in2: Inlet[Resp] = Inlet[Resp]("in1")
+  val out2: Outlet[(CIn, Resp)] = Outlet[(CIn, Resp)]("out2")
+
+  override def shape: BidiShape[(CIn, Req), Req, Resp, (CIn, Resp)] = BidiShape.of(in1, out1, in2, out2)
+
+  @scala.throws[Exception](classOf[Exception])
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+    var inTransit: Map[CMem, CIn] = Map.empty
+
+    setHandler(in1, new InHandler {
+      @scala.throws[Exception](classOf[Exception])
+      override def onPush(): Unit = {
+        val (cin, request) = grab(in1)
+        inTransit += correlator.extractRequestCorrelation(request) → cin
+        push(out1, request)
+      }
+
+      @scala.throws[Exception](classOf[Exception])
+      override def onUpstreamFinish(): Unit = complete(out1)
+    })
+
+    setHandler(out1, new OutHandler {
+      @scala.throws[Exception](classOf[Exception])
+      override def onPull(): Unit = if(!hasBeenPulled(in1)) tryPull(in1)
+
+      @scala.throws[Exception](classOf[Exception])
+      override def onDownstreamFinish(): Unit = cancel(in1)
+    })
+
+    setHandler(in2, new InHandler {
+      @scala.throws[Exception](classOf[Exception])
+      override def onPush(): Unit = {
+        val response = grab(in2)
+        val correlationId: CMem = correlator.correlateResponse(response)
+        val cin = inTransit.get(correlationId)
+
+        // This is probably a bit drastic
+        if(cin.isEmpty)
+          failStage(new IllegalStateException(s"[$correlationId] Received response without corresponding request"))
+
+        inTransit -= correlationId
+
+        push(out2, (cin.get, response))
+
+        if(inTransit.isEmpty && isClosed(in1))
+          completeStage()
+      }
+    })
+
+    setHandler(out2, new OutHandler {
+      @scala.throws[Exception](classOf[Exception])
+      override def onPull(): Unit = if(!hasBeenPulled(in1)) tryPull(in2)
+    })
+  }
+}

--- a/src/main/scala/akka/stream/integration/activemq/RecorrelatorBidiFlow.scala
+++ b/src/main/scala/akka/stream/integration/activemq/RecorrelatorBidiFlow.scala
@@ -73,7 +73,7 @@ class RecorrelatorBidiFlow[CIn, CMem, Req, Resp](correlator: Correlator[CMem, Re
       @scala.throws[Exception](classOf[Exception])
       override def onPush(): Unit = {
         val (cin, request) = grab(in1)
-        inTransit += correlator.extractRequestCorrelation(request) → cin
+        inTransit += correlator.extractRequestCorrelation(request) -> cin
         push(out1, request)
       }
 
@@ -102,7 +102,7 @@ class RecorrelatorBidiFlow[CIn, CMem, Req, Resp](correlator: Correlator[CMem, Re
             // This is probably a bit drastic
             failStage(new IllegalStateException(s"[$correlationId] Received response without corresponding request"))
           case Some(cin) =>
-            push(out2, (maybeCin.get, response))
+            push(out2, (cin, response))
         }
 
         if(inTransit.isEmpty && isClosed(in1))

--- a/src/test/scala/akka/stream/integration/TestSpec.scala
+++ b/src/test/scala/akka/stream/integration/TestSpec.scala
@@ -85,11 +85,11 @@ trait TestSpec extends FlatSpec
   def withTestTopicPublisher(endpoint: String = "PersonProducer")(f: TestPublisher.Probe[Person] => Unit): Unit =
     f(TestSource.probe[Person].to(ActiveMqProducer[Person](endpoint)).run())
 
-  def withTestTopicSubscriber(endpoint: String = "PersonConsumer")(f: TestSubscriber.Probe[AckUTup[Person]] => Unit): Unit =
-    f(ActiveMqConsumer[Person](endpoint).runWith(TestSink.probe[AckUTup[Person]]))
+  def withTestTopicSubscriber(endpoint: String = "PersonConsumer", poolSize: Int = 1)(f: TestSubscriber.Probe[AckUTup[Person]] => Unit): Unit =
+    f(ActiveMqConsumer[Person](endpoint, poolSize).runWith(TestSink.probe[AckUTup[Person]]))
 
-  def withRequestResponseSubscriber(endpoint: String = "PersonConsumer")(f: TestSubscriber.Probe[AckTup[Person, Person]] => Unit): Unit =
-    f(ActiveMqConsumer[Person, Person](endpoint).runWith(TestSink.probe[AckTup[Person, Person]]))
+  def withRequestResponseSubscriber(endpoint: String = "PersonConsumer", poolSize: Int = 1)(f: TestSubscriber.Probe[AckTup[Person, Person]] => Unit): Unit =
+    f(ActiveMqConsumer[Person, Person](endpoint, poolSize).runWith(TestSink.probe[AckTup[Person, Person]]))
 
   implicit class SourceOps[A](src: Source[A, NotUsed]) {
     def testProbe(f: TestSubscriber.Probe[A] => Unit): Unit =

--- a/src/test/scala/akka/stream/integration/activemq/AckBidiFlowTest.scala
+++ b/src/test/scala/akka/stream/integration/activemq/AckBidiFlowTest.scala
@@ -17,14 +17,17 @@
 package akka.stream.integration
 package activemq
 
+import akka.stream.integration.PersonDomain.Person
+
 import scala.concurrent.Promise
+import scala.concurrent.duration._
 
 class AckBidiFlowTest extends ActiveMqTestSpec {
 
   behavior of "AckBidiFlow"
 
   it should "propagate an element downstream, and propagate returned elements upstream, wrapped with the initial promise" in {
-    withBackendFlow { implicit backendFlow => flowProbe =>
+    withBackendFlow[Person, Person] { implicit backendFlow => flowProbe =>
       withAckBidiFlow { inputProbe => outputProbe =>
 
         val inputPromise = Promise[Unit]()
@@ -35,7 +38,7 @@ class AckBidiFlowTest extends ActiveMqTestSpec {
 
         outputProbe.request(1)
 
-        outputProbe.expectNoMsg()
+        outputProbe.expectNoMsg(100.milliseconds)
 
         flowProbe.reply(testPerson1)
 
@@ -47,7 +50,7 @@ class AckBidiFlowTest extends ActiveMqTestSpec {
   }
 
   it should "zip incoming promises with back-end values" in {
-    withBackendFlow { implicit backendFlow => flowProbe =>
+    withBackendFlow[Person, Person] { implicit backendFlow => flowProbe =>
       withAckBidiFlow { inputProbe => outputProbe =>
 
         val inputPromise1 = Promise[Unit]()
@@ -75,7 +78,7 @@ class AckBidiFlowTest extends ActiveMqTestSpec {
   }
 
   it should "respect buffer size" in {
-    withBackendFlow { implicit backendFlow => flowProbe =>
+    withBackendFlow[Person, Person] { implicit backendFlow => flowProbe =>
       withAckBidiFlow { inputProbe => outputProbe =>
 
         val inputPromise1 = Promise[Unit]()
@@ -88,7 +91,7 @@ class AckBidiFlowTest extends ActiveMqTestSpec {
         flowProbe.expectMsg(testPerson1)
 
         // assert that buffer-size of 1 is respected
-        flowProbe.expectNoMsg()
+        flowProbe.expectNoMsg(100.milliseconds)
       }
     }
   }

--- a/src/test/scala/akka/stream/integration/activemq/ActiveMqProducerSourceTest.scala
+++ b/src/test/scala/akka/stream/integration/activemq/ActiveMqProducerSourceTest.scala
@@ -41,7 +41,7 @@ class ActiveMqProducerSourceTest extends TestSpec {
       withTestTopicSubscriber(poolSize = 1) { sub2 =>
 
         withTestTopicPublisher() { pub =>
-          val testPersons = (1 to 2).map(i ⇒ testPerson2.copy(age = i))
+          val testPersons = (1 to 2).map(i => testPerson2.copy(age = i))
           testPersons foreach pub.sendNext
           pub.sendComplete()
 
@@ -76,7 +76,7 @@ class ActiveMqProducerSourceTest extends TestSpec {
     withTestTopicSubscriber(poolSize = 3) { sub =>
 
       withTestTopicPublisher() { pub =>
-        val testPersons = (1 to 5).map(i ⇒ testPerson2.copy(age = i))
+        val testPersons = (1 to 5).map(i => testPerson2.copy(age = i))
 
         // Make sure all consumers are up before sending messages (otherwise all messages on queue are allocated to a single consumer)
         eventually(consumerCount shouldBe 3)
@@ -91,8 +91,8 @@ class ActiveMqProducerSourceTest extends TestSpec {
 
         List(prom1, prom2, prom3) foreach (_.success(()))
 
-        val (prom4, per4) = sub.expectNextPF { case (p: Promise[Unit], person) if testPersons.contains(person) => (p, person) }
-        val (prom5, per5) = sub.expectNextPF { case (p: Promise[Unit], person) if testPersons.contains(person) => (p, person) }
+        val (prom4, per4) = sub.expectNextPF { case (p: Promise[Unit]@unchecked, person) if testPersons.contains(person) => (p, person) }
+        val (prom5, per5) = sub.expectNextPF { case (p: Promise[Unit]@unchecked, person) if testPersons.contains(person) => (p, person) }
 
         List(prom4, prom5) foreach (_.success(()))
 

--- a/src/test/scala/akka/stream/integration/activemq/ActiveMqProducerSourceTest.scala
+++ b/src/test/scala/akka/stream/integration/activemq/ActiveMqProducerSourceTest.scala
@@ -15,11 +15,12 @@
  */
 
 package akka.stream.integration
-package activemq
 
 import scala.concurrent.Promise
+import scala.concurrent.duration._
 
 class ActiveMqProducerSourceTest extends TestSpec {
+
   it should "consume messages from the queue" in {
     withTestTopicSubscriber() { sub =>
       withTestTopicPublisher() { pub =>
@@ -28,10 +29,81 @@ class ActiveMqProducerSourceTest extends TestSpec {
 
         sub.request(1)
         sub.expectNextPF {
-          case (p: Promise[Unit], `testPerson1`) => p.success(())
+          case (p: Promise[Unit]@unchecked, `testPerson1`) => p.success(())
         }
         sub.cancel()
       }
     }
   }
+
+  it should "support concurrent subscribers" in {
+    withTestTopicSubscriber(poolSize = 1) { sub1 =>
+      withTestTopicSubscriber(poolSize = 1) { sub2 =>
+
+        withTestTopicPublisher() { pub =>
+          val testPersons = (1 to 2).map(i ⇒ testPerson2.copy(age = i))
+          testPersons foreach pub.sendNext
+          pub.sendComplete()
+
+          sub1.request(1)
+          sub2.request(1)
+
+          // make sure both subscribers receive the one message requested
+          val (prom1, per1) = sub1.expectNextPF { case (p: Promise[Unit]@unchecked, person) if testPersons.contains(person) => (p, person) }
+          val (prom2, per2) = sub2.expectNextPF { case (p: Promise[Unit]@unchecked, person) if testPersons.contains(person) => (p, person) }
+
+          List(prom1, prom2) foreach (_.success(()))
+
+          // two messages were produced, two are consumed, nothing should remain
+          sub1.request(1)
+          sub2.request(1)
+          sub1.expectNoMsg(100.millis)
+          sub2.expectNoMsg(100.millis)
+
+          // make sure we have no duplicates
+          per1 should not be per2
+
+          sub1.cancel()
+          sub2.cancel()
+        }
+      }
+    }
+  }
+
+  it should "support a subscriber pool which can handle requests concurrently" in {
+    eventually(consumerCount shouldBe 0)
+
+    withTestTopicSubscriber(poolSize = 3) { sub =>
+
+      withTestTopicPublisher() { pub =>
+        val testPersons = (1 to 5).map(i ⇒ testPerson2.copy(age = i))
+
+        // Make sure all consumers are up before sending messages (otherwise all messages on queue are allocated to a single consumer)
+        eventually(consumerCount shouldBe 3)
+        testPersons foreach pub.sendNext
+        pub.sendComplete()
+
+        sub.request(5)
+        val (prom1, per1) = sub.expectNextPF { case (p: Promise[Unit]@unchecked, person) if testPersons.contains(person) => (p, person) }
+        val (prom2, per2) = sub.expectNextPF { case (p: Promise[Unit]@unchecked, person) if testPersons.contains(person) => (p, person) }
+        val (prom3, per3) = sub.expectNextPF { case (p: Promise[Unit]@unchecked, person) if testPersons.contains(person) => (p, person) }
+        sub.expectNoMsg(100.millis)
+
+        List(prom1, prom2, prom3) foreach (_.success(()))
+
+        val (prom4, per4) = sub.expectNextPF { case (p: Promise[Unit], person) if testPersons.contains(person) => (p, person) }
+        val (prom5, per5) = sub.expectNextPF { case (p: Promise[Unit], person) if testPersons.contains(person) => (p, person) }
+
+        List(prom4, prom5) foreach (_.success(()))
+
+        // make sure we have no duplicates
+        val firstBatch = List(per1, per2, per3, per4, per5)
+        firstBatch.distinct should contain theSameElementsAs firstBatch
+
+        sub.cancel()
+      }
+    }
+  }
+
+  def consumerCount: Int = getQueueStatFor("PersonConsumer").map(_.consumerCount).getOrElse(0)
 }

--- a/src/test/scala/akka/stream/integration/activemq/ActiveMqReqRespFlowTest.scala
+++ b/src/test/scala/akka/stream/integration/activemq/ActiveMqReqRespFlowTest.scala
@@ -29,7 +29,7 @@ class ActiveMqReqRespFlowTest extends ActiveMqTestSpec {
   behavior of "ActiveMqReqRespFlow"
 
   it should "support request-response for a single message" in {
-    withBackendFlow { implicit backendFlow => flowProbe =>
+    withBackendFlow[Person, Person] { implicit backendFlow => flowProbe =>
       withReqRespBidiFlow("AckBidiFlowReqRespTestInput") { testFlow =>
         withTestTopicPublisher("AckBidiFlowReqRespTestInput") { pub =>
           withTestTopicSubscriber("AckBidiFlowReqRespTestOutput") { sub =>
@@ -54,7 +54,7 @@ class ActiveMqReqRespFlowTest extends ActiveMqTestSpec {
   }
 
   it should "support request-response for a multiple messages" in {
-    withBackendFlow { implicit backendFlow => flowProbe =>
+    withBackendFlow[Person, Person] { implicit backendFlow => flowProbe =>
       withReqRespBidiFlow("AckBidiFlowReqRespTestInput") { testFlow =>
         withTestTopicPublisher("AckBidiFlowReqRespTestInput") { pub =>
           withTestTopicSubscriber("AckBidiFlowReqRespTestOutput") { sub =>

--- a/src/test/scala/akka/stream/integration/activemq/ActiveMqTestSpec.scala
+++ b/src/test/scala/akka/stream/integration/activemq/ActiveMqTestSpec.scala
@@ -19,16 +19,17 @@ package activemq
 
 import akka.NotUsed
 import akka.actor.ActorRef
+import akka.stream.integration.JsonCamelMessageBuilder._
+import akka.stream.integration.JsonCamelMessageExtractor._
 import akka.stream.integration.PersonDomain.Person
-import akka.stream.scaladsl.{ Flow, Keep }
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
-import akka.stream.testkit.{ TestPublisher, TestSubscriber }
+import akka.stream.scaladsl.{Flow, Keep}
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.stream.testkit.{TestPublisher, TestSubscriber}
 import akka.testkit.TestActor.AutoPilot
 import akka.testkit.TestProbe
-import JsonCamelMessageExtractor._
-import JsonCamelMessageBuilder._
 
-import scala.util.{ Failure, Success, Try }
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
 /**
  * Test fixtures for ActiveMq
  */
@@ -53,10 +54,10 @@ trait ActiveMqTestSpec extends TestSpec {
   /**
    * Creates a back-end flow whose messages can be intercepted using a traditional testprobe
    */
-  def withBackendFlow(test: Flow[Person, Person, NotUsed] => TestProbe => Any): Unit = {
+  def withBackendFlow[S, T: ClassTag](test: Flow[S, T, NotUsed] => TestProbe => Any): Unit = {
     import akka.pattern.ask
     val flowProbe = TestProbe()
-    val backendFlow = Flow[Person].mapAsync(1)(p => (flowProbe.ref ? p).mapTo[Person])
+    val backendFlow = Flow[S].mapAsync(1)(p => (flowProbe.ref ? p).mapTo[T])
     test(backendFlow)(flowProbe)
   }
 

--- a/src/test/scala/akka/stream/integration/activemq/RecorrelatorTest.scala
+++ b/src/test/scala/akka/stream/integration/activemq/RecorrelatorTest.scala
@@ -1,0 +1,180 @@
+package akka.stream.integration.activemq
+
+import java.util.UUID
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.integration.PersonDomain.Person
+import akka.stream.integration._
+import akka.stream.integration.activemq.RecorrelatorBidiFlow.Correlator
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.testkit.TestPublisher.Probe
+import akka.stream.testkit.TestSubscriber.Probe
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.stream.testkit.{TestPublisher, TestSubscriber}
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Promise}
+
+/**
+  *
+  */
+class RecorrelatorTest extends ActiveMqTestSpec {
+
+  import RecorrelatorTest._
+
+  behavior of "Recorrelator"
+
+  it should "perform a round-trip" in {
+    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow ⇒
+      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe ⇒ beInProbe ⇒ beOutProbe ⇒ feOutProbe ⇒
+
+        val inputPromise = Promise[Unit]()
+        val inputMessage = IdentifiedMessage()
+        val outputMessage = IdentifiedResponse(inputMessage.id)
+
+        beInProbe.ensureSubscription()
+        feOutProbe.ensureSubscription()
+
+        feInProbe.sendNext((inputPromise, inputMessage))
+
+        beInProbe.expectNoMsg(100.milliseconds)
+        beInProbe.requestNext(inputMessage)
+
+        beOutProbe.sendNext(outputMessage)
+
+        feOutProbe.expectNoMsg(100.milliseconds)
+        feOutProbe.requestNext((inputPromise, outputMessage))
+
+        beInProbe.expectNoMsg(100.milliseconds)
+        feOutProbe.expectNoMsg(100.milliseconds)
+
+        feInProbe.sendComplete()
+        beInProbe.expectComplete()
+
+        feOutProbe.cancel()
+        beOutProbe.expectCancellation()
+      }
+    }
+  }
+
+  it should "handle multiple messages" in {
+    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow ⇒
+      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe ⇒ beInProbe ⇒ beOutProbe ⇒ feOutProbe ⇒
+
+        val inputPromise1 = Promise[Unit]()
+        val inputPromise2 = Promise[Unit]()
+        val inputMessage1 = IdentifiedMessage()
+        val inputMessage2 = IdentifiedMessage()
+        val outputMessage1 = IdentifiedResponse(inputMessage1.id)
+        val outputMessage2 = IdentifiedResponse(inputMessage2.id)
+
+        beInProbe.ensureSubscription()
+        feOutProbe.ensureSubscription()
+
+        feInProbe.sendNext((inputPromise1, inputMessage1))
+        feInProbe.sendNext((inputPromise2, inputMessage2))
+
+        beInProbe.expectNoMsg(100.milliseconds)
+        beInProbe.requestNext(inputMessage1)
+
+        beOutProbe.sendNext(outputMessage1)
+
+        feOutProbe.expectNoMsg(100.milliseconds)
+        feOutProbe.requestNext((inputPromise1, outputMessage1))
+
+
+        beInProbe.expectNoMsg(100.milliseconds)
+        feOutProbe.expectNoMsg(100.milliseconds)
+
+        beInProbe.requestNext(inputMessage2)
+        beOutProbe.sendNext(outputMessage2)
+        feOutProbe.requestNext((inputPromise2, outputMessage2))
+
+        beInProbe.cancel()
+        feInProbe.expectCancellation()
+
+        beOutProbe.sendComplete()
+        feOutProbe.expectComplete()
+      }
+    }
+  }
+
+  it should "handle multiple messages, even if order is disturbed" in {
+    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow ⇒
+      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe ⇒ beInProbe ⇒ beOutProbe ⇒ feOutProbe ⇒
+
+        val inputPromise1 = Promise[Unit]()
+        val inputPromise2 = Promise[Unit]()
+        val inputMessage1 = IdentifiedMessage()
+        val inputMessage2 = IdentifiedMessage()
+        val outputMessage1 = IdentifiedResponse(inputMessage1.id)
+        val outputMessage2 = IdentifiedResponse(inputMessage2.id)
+
+        // propagate everything from front-end to back-end
+        beInProbe.ensureSubscription()
+        feOutProbe.ensureSubscription()
+
+        feInProbe.sendNext((inputPromise1, inputMessage1))
+        feInProbe.sendNext((inputPromise2, inputMessage2))
+        feInProbe.sendComplete()
+
+        beInProbe.requestNext(inputMessage1)
+        beInProbe.requestNext(inputMessage2)
+        beInProbe.expectComplete()
+
+        // and back, but changed order
+        beOutProbe.sendNext(outputMessage2)
+        beOutProbe.sendNext(outputMessage1)
+        beOutProbe.sendComplete()
+
+        feOutProbe.requestNext((inputPromise2, outputMessage2))
+        feOutProbe.requestNext((inputPromise1, outputMessage1))
+        feOutProbe.expectComplete()
+      }
+    }
+  }
+
+}
+
+object RecorrelatorTest {
+
+  case class IdentifiedMessage(id: UUID = UUID.randomUUID())
+  case class IdentifiedResponse(id: UUID = UUID.randomUUID())
+
+  def withRecorrelatorBidiFlow[C, I, O](correlator: Correlator[C, I, O])
+                              (test: TestPublisher.Probe[AckUTup[I]] ⇒ TestSubscriber.Probe[I] ⇒ TestPublisher.Probe[O] ⇒ TestSubscriber.Probe[AckUTup[O]] ⇒ Any)
+                              (implicit backendFlow: Flow[I, O, (TestSubscriber.Probe[I], TestPublisher.Probe[O])], system: ActorSystem, ec: ExecutionContext, mat: Materializer): Unit = {
+
+    val inputSource = TestSource.probe[AckUTup[I]]
+    val outputSink = TestSink.probe[AckUTup[O]]
+
+    val partialTestFlow: Flow[O, I, (TestPublisher.Probe[AckUTup[I]], TestSubscriber.Probe[AckUTup[O]])] =
+      ActiveMqFlow.applyMat(inputSource, outputSink, correlator)(Keep.both)
+
+    val ((feInProbe, feOutProbe), (beInProbe, beOutProbe)) = partialTestFlow.joinMat(backendFlow)(Keep.both).run()
+
+    test(feInProbe)(beInProbe)(beOutProbe)(feOutProbe)
+  }
+
+  def withBackEnd[I, O](test: Flow[I, O, (TestSubscriber.Probe[I], TestPublisher.Probe[O])] ⇒ Any)(implicit system: ActorSystem): Unit = {
+    val backEndSink: Sink[I, TestSubscriber.Probe[I]] = TestSink.probe[I]
+    val backEndSource: Source[O, TestPublisher.Probe[O]] = TestSource.probe[O]
+    val flow: Flow[I, O, (TestSubscriber.Probe[I], TestPublisher.Probe[O])] = Flow.fromSinkAndSourceMat(backEndSink, backEndSource)(Keep.both)
+    test(flow)
+  }
+
+  val defaultCorrelator: Correlator[UUID, IdentifiedMessage, IdentifiedResponse] = new Correlator[UUID, IdentifiedMessage, IdentifiedResponse] {
+    /**
+      * Use this to extract an identifier from the request that can be used to correlate its response
+      */
+    override def extractRequestCorrelation: IdentifiedMessage ⇒ UUID = _.id
+
+    /**
+      * Use this to extract from a response that can be used to correlate it to the original request
+      */
+    override def correlateResponse: IdentifiedResponse ⇒ UUID = _.id
+  }
+
+}

--- a/src/test/scala/akka/stream/integration/activemq/RecorrelatorTest.scala
+++ b/src/test/scala/akka/stream/integration/activemq/RecorrelatorTest.scala
@@ -27,8 +27,8 @@ class RecorrelatorTest extends ActiveMqTestSpec {
   behavior of "Recorrelator"
 
   it should "perform a round-trip" in {
-    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow ⇒
-      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe ⇒ beInProbe ⇒ beOutProbe ⇒ feOutProbe ⇒
+    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow =>
+      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe => beInProbe => beOutProbe => feOutProbe =>
 
         val inputPromise = Promise[Unit]()
         val inputMessage = IdentifiedMessage()
@@ -60,8 +60,8 @@ class RecorrelatorTest extends ActiveMqTestSpec {
   }
 
   it should "handle multiple messages" in {
-    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow ⇒
-      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe ⇒ beInProbe ⇒ beOutProbe ⇒ feOutProbe ⇒
+    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow =>
+      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe => beInProbe => beOutProbe => feOutProbe =>
 
         val inputPromise1 = Promise[Unit]()
         val inputPromise2 = Promise[Unit]()
@@ -102,8 +102,8 @@ class RecorrelatorTest extends ActiveMqTestSpec {
   }
 
   it should "handle multiple messages, even if order is disturbed" in {
-    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow ⇒
-      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe ⇒ beInProbe ⇒ beOutProbe ⇒ feOutProbe ⇒
+    withBackEnd[IdentifiedMessage, IdentifiedResponse] { implicit backendFlow =>
+      withRecorrelatorBidiFlow(defaultCorrelator) { feInProbe => beInProbe => beOutProbe => feOutProbe =>
 
         val inputPromise1 = Promise[Unit]()
         val inputPromise2 = Promise[Unit]()
@@ -144,7 +144,7 @@ object RecorrelatorTest {
   case class IdentifiedResponse(id: UUID = UUID.randomUUID())
 
   def withRecorrelatorBidiFlow[C, I, O](correlator: Correlator[C, I, O])
-                              (test: TestPublisher.Probe[AckUTup[I]] ⇒ TestSubscriber.Probe[I] ⇒ TestPublisher.Probe[O] ⇒ TestSubscriber.Probe[AckUTup[O]] ⇒ Any)
+                              (test: TestPublisher.Probe[AckUTup[I]] => TestSubscriber.Probe[I] => TestPublisher.Probe[O] => TestSubscriber.Probe[AckUTup[O]] => Any)
                               (implicit backendFlow: Flow[I, O, (TestSubscriber.Probe[I], TestPublisher.Probe[O])], system: ActorSystem, ec: ExecutionContext, mat: Materializer): Unit = {
 
     val inputSource = TestSource.probe[AckUTup[I]]
@@ -158,7 +158,7 @@ object RecorrelatorTest {
     test(feInProbe)(beInProbe)(beOutProbe)(feOutProbe)
   }
 
-  def withBackEnd[I, O](test: Flow[I, O, (TestSubscriber.Probe[I], TestPublisher.Probe[O])] ⇒ Any)(implicit system: ActorSystem): Unit = {
+  def withBackEnd[I, O](test: Flow[I, O, (TestSubscriber.Probe[I], TestPublisher.Probe[O])] => Any)(implicit system: ActorSystem): Unit = {
     val backEndSink: Sink[I, TestSubscriber.Probe[I]] = TestSink.probe[I]
     val backEndSource: Source[O, TestPublisher.Probe[O]] = TestSource.probe[O]
     val flow: Flow[I, O, (TestSubscriber.Probe[I], TestPublisher.Probe[O])] = Flow.fromSinkAndSourceMat(backEndSink, backEndSource)(Keep.both)
@@ -169,12 +169,12 @@ object RecorrelatorTest {
     /**
       * Use this to extract an identifier from the request that can be used to correlate its response
       */
-    override def extractRequestCorrelation: IdentifiedMessage ⇒ UUID = _.id
+    override def extractRequestCorrelation: IdentifiedMessage => UUID = _.id
 
     /**
       * Use this to extract from a response that can be used to correlate it to the original request
       */
-    override def correlateResponse: IdentifiedResponse ⇒ UUID = _.id
+    override def correlateResponse: IdentifiedResponse => UUID = _.id
   }
 
 }


### PR DESCRIPTION
Two significant changes:
- ActiveMqConsumer now includes a poolSize, which controls the maximum number of parallel in-transit requests. It uses the simplest mechanism I could find (although more costly than I had hoped for), simply instantiating multiple ActiveMq-sources and combining them into one. **Use case**: I like to use 'grouped' combinator to create mini-batches over a window. This mechanism could not be put to effective use with a Source that allows only a single in-transit message
- Included Recorrelator, which allows for a cleaner application interface (not thinking in 'technical' terms of promises/actor-refs). The supplied correlator defines a context for the message that is used to find back the original promise-actor-ref. **Use case**: The AckBidiFlow does not deal with the application-flow being disorderly. Recorrelator is not sensitve to reordering (but admittedly, still has a bunch of possible improvements.)

Let me know what you think! :)
