### PR TITLE
Allow overriding the name of consumers using a name configuration key

### DIFF
--- a/src/main/scala/akka/stream/integration/activemq/extension/ActiveMqExtension.scala
+++ b/src/main/scala/akka/stream/integration/activemq/extension/ActiveMqExtension.scala
@@ -56,7 +56,7 @@ class ActiveMqExtensionImpl(val system: ExtendedActorSystem) extends Extension w
   }
 
   override def consumerEndpointUri(consumerName: String): String =
-    ConsumerConfig(system.settings.config.getConfig(consumerName), Some(consumerName)).endpoint
+    ConsumerConfig(system.settings.config.getConfig(consumerName), consumerName).endpoint
 
   override def producerEndpointUri(producerName: String): String =
     ProducerConfig(system.settings.config.getConfig(producerName)).endpoint

--- a/src/main/scala/akka/stream/integration/activemq/extension/config/ConsumerConfig.scala
+++ b/src/main/scala/akka/stream/integration/activemq/extension/config/ConsumerConfig.scala
@@ -17,10 +17,11 @@
 package akka.stream.integration.activemq.extension.config
 
 import com.typesafe.config.Config
+import scalaz.syntax.std.boolean._
 
 object ConsumerConfig {
-  def apply(config: Config, name: Option[String] = None): ConsumerConfig = ConsumerConfig(
-    name.getOrElse(config.getString("name")),
+  def apply(config: Config, name: String): ConsumerConfig = ConsumerConfig(
+    config.hasPath("name") ? config.getString("name") | name,
     config.getString("conn"),
     config.getString("queue"),
     config.getString("concurrentConsumers")


### PR DESCRIPTION
Now it was the case that the name specified in code (the name of the consumer configuration key) was prioritised over the "name" configuration parameter within the consumer configuration. As it is always specified, "name" was nullified. This change inverts the prioritisation. 