### PR TITLE
Cross build for both Scala 2.12 and 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - docker inspect activemq
 scala:
   - "2.11.8"
+  - "2.12.1"
 jdk:
   - oraclejdk8
 branches:

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,9 @@ organization := "com.github.dnvriend"
 
 version := "0.0.27"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
+
+crossScalaVersions := Seq(scalaVersion.value, "2.11.8")
 
 testOptions in Test += Tests.Argument("-oD")
 

--- a/src/test/scala/akka/stream/integration/TestSpec.scala
+++ b/src/test/scala/akka/stream/integration/TestSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 
 import akka.actor.{ ActorRef, ActorSystem, PoisonPill }
 import akka.camel.CamelExtension
-import akka.event.{ Logging, LoggingAdapter }
+import akka.event.{ Logging, LoggingAdapter, LogSource }
 import akka.stream.integration.activemq.{ ActiveMqConsumer, ActiveMqProducer }
 import akka.stream.scaladsl.{ Keep, Source }
 import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
@@ -63,7 +63,10 @@ trait TestSpec extends FlatSpec
   implicit val system: ActorSystem = ActorSystem()
   implicit val mat: Materializer = ActorMaterializer()
   implicit val ec: ExecutionContext = system.dispatcher
-  val log: LoggingAdapter = Logging(system, this.getClass)
+  implicit val logSource: LogSource[TestSpec] = new LogSource[TestSpec] {
+    def genString(a: TestSpec) = a.getClass.getSimpleName
+  }
+  val log: LoggingAdapter = Logging(system, this)
   implicit val pc: PatienceConfig = PatienceConfig(timeout = 60.seconds)
   implicit val timeout = Timeout(30.seconds)
 


### PR DESCRIPTION
The logging creation in TestSpec failed on 2.12 for some reason. Adding a `LogSource` fixes the problem